### PR TITLE
Classify newer GCP service attack paths in the risk rules

### DIFF
--- a/src/CloudPEASS/risk_rules/gcp.yaml
+++ b/src/CloudPEASS/risk_rules/gcp.yaml
@@ -40,6 +40,10 @@ critical_exact:
   - iam.googleapis.com/workloadIdentityPools.undelete
   - iam.googleapis.com/workloadIdentityPools.update
   - integrations.authConfigs.get
+  # Config Controller / KCC: taking the KRM API host IAM policy grants cluster
+  # access, then applied KRM resources execute as the roles/owner Config
+  # Connector identity, escalating to project takeover.
+  - krmapihosting.krmApiHosts.setIamPolicy
   - osconfig.patchJobs.exec
   - resourcemanager.folders.setIamPolicy
   - resourcemanager.organizations.setIamPolicy
@@ -157,6 +161,110 @@ high_exact:
   - workflows.stepEntries.list
   - workflows.workflows.get
   - workflows.workflows.list
+  # --- Newer service attack paths. Each service family below has matching
+  # HackTricks evidence in sensitive_permissions.gcp (risk_documentation). ---
+  # Bare Metal Solution: SSH-key plant / serial console = host code execution;
+  # NFS export tampering exposes enterprise data.
+  - baremetalsolution.instances.enableInteractiveSerialConsole
+  - baremetalsolution.nfsshares.update
+  - baremetalsolution.sshKeys.create
+  # BigLake: repointing a catalog/database/namespace/table storage LOCATION to
+  # an attacker bucket poisons downstream query reads.
+  - biglake.catalogs.update
+  - biglake.databases.update
+  - biglake.namespaces.update
+  - biglake.tables.update
+  # BigQuery connections: managed-SA read-through, EXTERNAL_QUERY against stored
+  # Cloud SQL credentials, and credential/instance repointing.
+  - bigquery.connections.create
+  - bigquery.connections.update
+  - bigquery.connections.use
+  # Cloud KMS EKM: repointing an EKM connection or the location default gives
+  # MITM over external key wrap/unwrap material.
+  - cloudkms.ekmConfigs.update
+  - cloudkms.ekmConnections.update
+  # Cloud Trace / Error Reporting: span labels and error payloads routinely leak
+  # tokens, connection strings, and secret names.
+  - cloudtrace.traces.get
+  - cloudtrace.traces.list
+  - errorreporting.errorEvents.list
+  - errorreporting.groups.list
+  # Contact Center AI Insights: confused-deputy GCS reads, full transcript/PII
+  # disclosure, and export to an attacker-owned BigQuery dataset.
+  - contactcenterinsights.conversations.create
+  - contactcenterinsights.conversations.export
+  - contactcenterinsights.conversations.get
+  - contactcenterinsights.conversations.upload
+  # Vertex AI Search (Discovery Engine): corpus read/exfil, confused-deputy
+  # import, and RAG poisoning of served documents/sites.
+  - discoveryengine.documents.create
+  - discoveryengine.documents.get
+  - discoveryengine.documents.import
+  - discoveryengine.documents.list
+  - discoveryengine.documents.update
+  - discoveryengine.servingConfigs.answer
+  - discoveryengine.servingConfigs.search
+  - discoveryengine.targetSites.create
+  # Cloud Domains: NS repoint, EPP auth-code disclosure / transfer takeover, and
+  # registrant PII exposure.
+  - domains.registrations.configureContact
+  - domains.registrations.configureDns
+  - domains.registrations.configureManagement
+  - domains.registrations.update
+  # Live Stream: confused-deputy channel/asset storage access and secret ingest
+  # URI disclosure.
+  - livestream.assets.create
+  - livestream.channels.create
+  - livestream.inputs.get
+  - livestream.inputs.list
+  # Looker: export redirection to an attacker bucket and SSO-app hijack.
+  - looker.instances.export
+  - looker.instances.update
+  # Managed Kafka: broker consume/produce, connector exfil/injection, and Secret
+  # Manager version disclosure into an attacker-controlled Connect worker.
+  - managedkafka.clusters.connect
+  - managedkafka.connectClusters.create
+  - managedkafka.connectClusters.update
+  - managedkafka.connectors.create
+  - managedkafka.connectors.update
+  # NetApp Volumes: export-policy tampering and snapshot/backup exfil-clone.
+  - netapp.backups.create
+  - netapp.backups.createCrossProjectBackup
+  - netapp.snapshots.create
+  - netapp.storagePools.restoreVolume
+  - netapp.volumes.createCrossProjectBackup
+  - netapp.volumes.restore
+  - netapp.volumes.update
+  # Network Security: TLS-policy downgrade to plaintext enables MITM/credential
+  # sniffing of the referencing endpoints.
+  - networksecurity.clientTlsPolicies.create
+  - networksecurity.clientTlsPolicies.update
+  - networksecurity.serverTlsPolicies.create
+  - networksecurity.serverTlsPolicies.update
+  # Network Services: HttpRoute / EndpointPolicy hijack reroutes or downgrades
+  # in-mesh traffic for MITM/credential capture.
+  - networkservices.endpointPolicies.create
+  - networkservices.endpointPolicies.update
+  - networkservices.httpRoutes.create
+  - networkservices.httpRoutes.update
+  # Parallelstore: confused-deputy filesystem export (exfil) and import (poison).
+  - parallelstore.instances.exportData
+  - parallelstore.instances.importData
+  # Transcoder: confused-deputy job reads a victim GCS input and writes output to
+  # an attacker-reachable bucket.
+  - transcoder.jobs.create
+  # VM Migration: clone/cutover materializes replicated source disks into an
+  # attacker-controlled instance/project = whole-VM data exfil.
+  - vmmigration.cloneJobs.create
+  - vmmigration.cutoverJobs.create
+  - vmmigration.migratingVms.update
+  - vmmigration.targets.create
+  # VMware Engine (GCVE): show/reset returns cleartext vCenter/NSX-T admin
+  # credentials = full control of the SDDC and its guest VMs.
+  - vmwareengine.privateClouds.resetNsxCredentials
+  - vmwareengine.privateClouds.resetVcenterCredentials
+  - vmwareengine.privateClouds.showNsxCredentials
+  - vmwareengine.privateClouds.showVcenterCredentials
 
 # Exact overrides for names that contain security-looking words but disclose
 # only metadata or perform ordinary lifecycle operations.
@@ -218,6 +326,9 @@ medium_exact:
   - logging.views.access
   - managedidentities.domains.resetpassword
   - monitoring.dashboards.delete
+  # Candidate SMB domain-join credential read; kept medium because the API may
+  # redact the stored password.
+  - netapp.activeDirectories.get
   - networkmanagement.providers.generateProviderAccessToken
   - recaptchaenterprise.keys.retrievelegacysecretkey
   - run.jobs.run
@@ -236,10 +347,6 @@ medium_exact:
   - spanner.databases.write
   - storage.objects.update
   - transferappliance.credentials.get
-  - vmwareengine.privateClouds.resetNsxCredentials
-  - vmwareengine.privateClouds.resetVcenterCredentials
-  - vmwareengine.privateClouds.showNsxCredentials
-  - vmwareengine.privateClouds.showVcenterCredentials
 
 low_exact:
   - cloudasset.assets.listSecretManagerSecretVersions

--- a/src/sensitive_permissions/gcp.py
+++ b/src/sensitive_permissions/gcp.py
@@ -107,6 +107,13 @@ very_sensitive_combinations = [
     # Database account takeover.
     ["cloudsql.users.create"],
     ["cloudsql.users.update"],
+
+    # Registering a Migration Center discovery client with a caller-specified
+    # service account impersonates it (actAs-gated).
+    [
+        "migrationcenter.discoveryClients.create",
+        "iam.serviceAccounts.actAs",
+    ],
 ]
 
 
@@ -380,4 +387,25 @@ risk_documentation = (
     ("spanner.*", "gcp-post-exploitation/gcp-spanner-post-exploitation.md"),
     ("storage.*", "gcp-privilege-escalation/gcp-storage-privesc.md"),
     ("workflows.*", "gcp-privilege-escalation/gcp-workflows-privesc.md"),
+    # Newer service attack paths. Some are documented on the service enum pages
+    # under gcp-services/ rather than a dedicated privesc/post-exploitation page.
+    ("baremetalsolution.*", "gcp-services/gcp-bare-metal-solution-enum.md"),
+    ("biglake.*", "gcp-services/gcp-biglake-enum.md"),
+    ("cloudtrace.*", "gcp-services/gcp-trace-profiler-error-reporting-enum.md"),
+    ("contactcenterinsights.*", "gcp-services/gcp-contact-center-insights-enum.md"),
+    ("discoveryengine.*", "gcp-services/gcp-vertex-ai-search-enum.md"),
+    ("domains.*", "gcp-post-exploitation/gcp-cloud-domains-post-exploitation.md"),
+    ("errorreporting.*", "gcp-services/gcp-trace-profiler-error-reporting-enum.md"),
+    ("krmapihosting.*", "gcp-services/gcp-config-controller-enum.md"),
+    ("livestream.*", "gcp-post-exploitation/gcp-live-stream-post-exploitation.md"),
+    ("looker.*", "gcp-services/gcp-looker-enum.md"),
+    ("managedkafka.*", "gcp-services/gcp-managed-kafka-enum.md"),
+    ("migrationcenter.*", "gcp-services/gcp-migration-center-enum.md"),
+    ("netapp.*", "gcp-services/gcp-netapp-volumes-enum.md"),
+    ("networksecurity.*", "gcp-privilege-escalation/gcp-networksecurity-privesc.md"),
+    ("networkservices.*", "gcp-privilege-escalation/gcp-networkservices-privesc.md"),
+    ("parallelstore.*", "gcp-privilege-escalation/gcp-parallelstore-privesc.md"),
+    ("transcoder.*", "gcp-post-exploitation/gcp-transcoder-post-exploitation.md"),
+    ("vmmigration.*", "gcp-services/gcp-vm-migration-enum.md"),
+    ("vmwareengine.*", "gcp-services/gcp-vmwareengine-gcve-enum.md"),
 )

--- a/tests/test_gcp_permission_risks.py
+++ b/tests/test_gcp_permission_risks.py
@@ -416,6 +416,131 @@ def test_every_high_or_critical_rule_has_hacktricks_evidence():
                 "gcp-privilege-escalation/",
                 "gcp-post-exploitation/",
                 "gcp-to-workspace-pivoting/",
+                # Some newer services document their abuse on the service enum
+                # page rather than a dedicated privesc/post-exploitation page.
+                "gcp-services/",
             )
         )
         assert document.endswith(".md")
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        # Config Controller / KCC: KRM API host IAM takeover -> owner-level KCC.
+        "krmapihosting.krmApiHosts.setIamPolicy",
+    ],
+)
+def test_newer_service_takeovers_are_critical(permission):
+    assert classify_permission("gcp", permission) == "critical"
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        # Bare Metal Solution host code execution / data exposure.
+        "baremetalsolution.sshKeys.create",
+        "baremetalsolution.instances.enableInteractiveSerialConsole",
+        "baremetalsolution.nfsshares.update",
+        # BigLake storage-location repointing (data poisoning / read-MITM).
+        "biglake.tables.update",
+        "biglake.catalogs.update",
+        # BigQuery connection read-through and credential repointing.
+        "bigquery.connections.create",
+        "bigquery.connections.use",
+        "bigquery.connections.update",
+        # Cloud KMS EKM MITM over external key material.
+        "cloudkms.ekmConnections.update",
+        "cloudkms.ekmConfigs.update",
+        # Cloud Trace / Error Reporting secret leakage.
+        "cloudtrace.traces.get",
+        "cloudtrace.traces.list",
+        "errorreporting.groups.list",
+        "errorreporting.errorEvents.list",
+        # Contact Center AI Insights confused-deputy reads and PII disclosure.
+        "contactcenterinsights.conversations.get",
+        "contactcenterinsights.conversations.export",
+        # Cloud Domains hijack / auth-code disclosure.
+        "domains.registrations.configureDns",
+        "domains.registrations.update",
+        "domains.registrations.configureManagement",
+        "domains.registrations.configureContact",
+        # Vertex AI Search corpus exfil and RAG poisoning.
+        "discoveryengine.documents.get",
+        "discoveryengine.documents.import",
+        "discoveryengine.servingConfigs.search",
+        "discoveryengine.servingConfigs.answer",
+        "discoveryengine.targetSites.create",
+        # Live Stream confused-deputy storage and ingest-URI disclosure.
+        "livestream.channels.create",
+        "livestream.inputs.get",
+        "livestream.inputs.list",
+        # Looker export redirection / SSO hijack.
+        "looker.instances.export",
+        "looker.instances.update",
+        # Managed Kafka data-plane and Secret Manager disclosure.
+        "managedkafka.clusters.connect",
+        "managedkafka.connectors.create",
+        "managedkafka.connectClusters.create",
+        "managedkafka.connectClusters.update",
+        # NetApp Volumes export tampering and exfil-clone.
+        "netapp.volumes.update",
+        "netapp.snapshots.create",
+        "netapp.volumes.restore",
+        "netapp.storagePools.restoreVolume",
+        # Network Security TLS downgrade MITM.
+        "networksecurity.serverTlsPolicies.update",
+        "networksecurity.clientTlsPolicies.create",
+        # Network Services mesh route/endpoint hijack.
+        "networkservices.httpRoutes.create",
+        "networkservices.endpointPolicies.update",
+        # Parallelstore confused-deputy export/import.
+        "parallelstore.instances.exportData",
+        "parallelstore.instances.importData",
+        # Transcoder confused-deputy job.
+        "transcoder.jobs.create",
+        # VM Migration whole-VM disk exfil.
+        "vmmigration.cloneJobs.create",
+        "vmmigration.cutoverJobs.create",
+        "vmmigration.migratingVms.update",
+        "vmmigration.targets.create",
+        # VMware Engine (GCVE) cleartext admin credential return.
+        "vmwareengine.privateClouds.showVcenterCredentials",
+        "vmwareengine.privateClouds.showNsxCredentials",
+        "vmwareengine.privateClouds.resetVcenterCredentials",
+        "vmwareengine.privateClouds.resetNsxCredentials",
+    ],
+)
+def test_newer_service_attack_permissions_are_high(permission):
+    assert classify_permission("gcp", permission) == "high"
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        # Candidate SMB domain-join credential read; may be redacted by the API.
+        "netapp.activeDirectories.get",
+    ],
+)
+def test_speculative_credential_reads_are_medium(permission):
+    assert classify_permission("gcp", permission, unknown_default="medium") == "medium"
+
+
+def test_migration_center_discovery_client_is_critical_only_with_actas():
+    peass = CloudPEASS(
+        very_sensitive_combinations,
+        sensitive_combinations,
+        "GCP",
+        1,
+    )
+    incomplete = peass.analyze_sensitive_combinations(
+        {"migrationcenter.discoveryClients.create"}
+    )
+    assert incomplete["very_sensitive_perms"] == set()
+
+    complete = {
+        "migrationcenter.discoveryClients.create",
+        "iam.serviceAccounts.actAs",
+    }
+    result = peass.analyze_sensitive_combinations(complete)
+    assert complete <= result["very_sensitive_perms"]


### PR DESCRIPTION
## What

Extends the GCP permission risk classifier (`risk_rules/gcp.yaml`) and the combination catalog (`sensitive_permissions/gcp.py`) so GCPPEASS categorizes the permissions behind the recently documented GCP service attacks, instead of falling back to verb heuristics (which under-rated several sensitive data-plane reads as `low`).

Both report paths are updated at once: `analyze_sensitive_combinations` already merges `classify_all` output (critical→very-sensitive, high→sensitive), so the YAML additions flow into both the risk buckets and the combination report.

## Changes

**`src/CloudPEASS/risk_rules/gcp.yaml`**
- New `high_exact` entries for: Bare Metal Solution (SSH-key plant / serial console / NFS export tamper), BigLake storage-location repointing, BigQuery connection read-through & credential repointing, Cloud KMS EKM MITM, Cloud Trace / Error Reporting secret leakage, Contact Center AI Insights confused-deputy reads & PII, Cloud Domains hijack / EPP auth-code disclosure, Vertex AI Search (Discovery Engine) corpus exfil & RAG poisoning, Live Stream, Looker export redirection, Managed Kafka data-plane & Secret Manager disclosure, NetApp Volumes export tamper & exfil-clone, Network Security TLS-downgrade MITM, Network Services mesh route/endpoint hijack, Parallelstore confused-deputy export/import, Transcoder confused-deputy job, VM Migration whole-VM disk exfil.
- Promote VMware Engine (GCVE) `show*/reset*Credentials` from `medium` → `high` (they return cleartext vCenter/NSX-T admin credentials = full SDDC control).
- Add Config Controller / KCC `krmapihosting.krmApiHosts.setIamPolicy` to `critical_exact`.
- Keep the speculative NetApp AD credential read at `medium` (the API may redact the password).

**`src/sensitive_permissions/gcp.py`**
- Add the Migration Center discovery-client `actAs` impersonation combination.
- Add `risk_documentation` families mapping each new service to its HackTricks Cloud page.

**`tests/test_gcp_permission_risks.py`**
- Cover the new critical/high/medium classifications and the Migration Center combination.
- Allow `gcp-services/` enum pages as evidence for services whose abuse is documented there rather than on a dedicated privesc/post-exploitation page.

## Testing
- `tests/test_gcp_permission_risks.py` — 198 passed
- `tests/test_gcppeass.py` — 106 passed
- `tests/test_permission_risk_classifier.py` — 46 passed (388 subtests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)